### PR TITLE
fix: generate 16-byte DB_ENC_KEY so Realtime doesn't crash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -74,7 +74,9 @@ SERVICE_ROLE_KEY=$(sign_jwt "service_role")
 
 # Generate optional security keys
 SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')
-DB_ENC_KEY=$(openssl rand -hex 16)
+# Realtime uses AES-128-ECB, which requires a 16-byte key.
+# `openssl rand -hex 8` emits 16 ASCII chars = 16 bytes.
+DB_ENC_KEY=$(openssl rand -hex 8)
 
 # ── Self-test: verify JWT header decodes correctly ────────────
 


### PR DESCRIPTION
## Summary
- `setup.sh` generated `DB_ENC_KEY` with `openssl rand -hex 16` → 32 hex chars (32 bytes).
- Supabase Realtime encrypts tenant data with AES-128-ECB, which requires a **16-byte** key. The 32-byte value made Realtime crash-loop on every fresh `setup.sh` install with `{:badarg, ~c"Bad key size"}` from `Realtime.Crypto.encrypt!/1`.
- Switch to `openssl rand -hex 8` (16 hex chars = 16 bytes).

Fixes #4

## Repro (before the fix)
```
$ ./setup.sh && docker compose -f docker-compose.stable.yml up -d
$ docker logs <project>-realtime-1
** (ErlangError) Erlang error: {:badarg, {~c"api_ng.c", 244}, ~c"Bad key size"}
    :crypto.crypto_one_time(:aes_128_ecb, "<32 hex chars>", ..., true)
    (realtime 2.76.5) lib/realtime/crypto.ex:14: Realtime.Crypto.encrypt!/1
    /app/lib/realtime-2.76.5/priv/repo/seeds.exs:20: (file)
```

## Test plan
- [x] Ran `setup.sh` with the fix applied on a clean clone
- [x] `docker compose -f docker-compose.stable.yml up -d`
- [x] Realtime container: `status=running restarts=0` after 45s (was crash-looping before)
- [x] All other services healthy (db, auth, rest, storage, kong, meta, studio, frontend, functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)